### PR TITLE
minor UI modifications

### DIFF
--- a/res/layout/branch.xml
+++ b/res/layout/branch.xml
@@ -23,12 +23,19 @@
 				android:textStyle="bold"
 				android:textSize="24dip" />
 			<TextView
-				android:id="@+id/tv_branch_sha"
+				android:id="@+id/tv_branch_sha_head"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_below="@id/tv_branch_name"
 				android:layout_alignLeft="@id/tv_branch_name"
-				android:textSize="16dip" />
+				android:textSize="18dip" />
+			<TextView
+				android:id="@+id/tv_branch_sha_tail"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_alignBaseline="@id/tv_branch_sha_head"
+				android:layout_toRightOf="@id/tv_branch_sha_head"
+				android:textSize="12dip" />
 		</RelativeLayout>
 		<LinearLayout
 			android:id="@+id/ll_branch_strip"

--- a/res/layout/login.xml
+++ b/res/layout/login.xml
@@ -80,7 +80,8 @@
 			android:layout_height="wrap_content"
 			android:singleLine="true"
 			android:inputType="textPassword"
-			android:background="@android:drawable/editbox_background" />
+			android:background="@android:drawable/editbox_background"
+			android:nextFocusDown="@+id/btn_login_login" />
 		<Button
 			android:layout_marginLeft="20dip"
 		    android:layout_toRightOf="@id/tv_login_username_label"

--- a/src/net/idlesoft/android/apps/github/activities/Branch.java
+++ b/src/net/idlesoft/android/apps/github/activities/Branch.java
@@ -73,12 +73,18 @@ public class Branch extends Activity {
             mBranchName = extras.getString("branch_name");
             mBranchSha = extras.getString("branch_sha");
 
+            // Break mBranchSha into two pieces - the first seven chars and the rest.
+            final String branch_sha_head = mBranchSha.substring(0, 7);
+            final String branch_sha_tail = mBranchSha.substring(7, 40);
+
             final TextView branchName = (TextView) findViewById(R.id.tv_branch_name);
-            final TextView branchSha = (TextView) findViewById(R.id.tv_branch_sha);
+            final TextView branchShaHead = (TextView) findViewById(R.id.tv_branch_sha_head);
+            final TextView branchShaTail = (TextView) findViewById(R.id.tv_branch_sha_tail);
             final ListView infoList = (ListView) findViewById(R.id.lv_branch_infoList);
 
             branchName.setText(mBranchName);
-            branchSha.setText(mBranchSha);
+            branchShaHead.setText(branch_sha_head);
+            branchShaTail.setText(branch_sha_tail);
 
             infoList.setAdapter(new ArrayAdapter<String>(Branch.this, R.layout.branch_info_item,
                     R.id.tv_branchInfoItem_text1, new String[] {


### PR DESCRIPTION
I found hubroid on the Market the other day - very cool. This pull request contains two unrelated little things I thought might be improvements while I was playing around.

11a65dc: Setting the password field's nextFocusDown to the login button is an affordance that I suspect a reasonable number of users will appreciate, particularly those on devices with hardware keyboards.

ca3ae68: I started on this part when I noticed that the SHA1 text wrapped on both of my devices in portrait (both with horizontal resolutions of 480px). Not sure how useful having the sums at all is, but I'm a nerd, so I like seeing them. :) Emphasizing the first few characters makes it easier to parse, though the overall effect is that they now fit on such screens. As for hard-coding 7, that seems to be the git convention for shortening, and I can't imagine any sufficient use case that would justify making it configurable.
-Ted
