### PR TITLE
Fix for issue #47, incorrect current time

### DIFF
--- a/src/net/idlesoft/android/apps/github/activities/Commit.java
+++ b/src/net/idlesoft/android/apps/github/activities/Commit.java
@@ -219,7 +219,7 @@ public class Commit extends Activity {
 
             try {
                 commit_time = dateFormat.parse(mJson.getString("authored_date"));
-                current_time = dateFormat.parse(dateFormat.format(new Date()));
+                current_time = new Date();
                 ((TextView) findViewById(R.id.commit_view_author_time)).setText(Commit
                         .getHumanDate(current_time, commit_time));
 

--- a/src/net/idlesoft/android/apps/github/activities/SingleActivityItem.java
+++ b/src/net/idlesoft/android/apps/github/activities/SingleActivityItem.java
@@ -60,7 +60,7 @@ public class SingleActivityItem extends Activity {
             final SimpleDateFormat dateFormat = new SimpleDateFormat(
                     Hubroid.GITHUB_ISSUES_TIME_FORMAT);
             final Date item_time = dateFormat.parse(entry.getString("created_at"));
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - item_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;

--- a/src/net/idlesoft/android/apps/github/activities/SingleIssue.java
+++ b/src/net/idlesoft/android/apps/github/activities/SingleIssue.java
@@ -166,7 +166,7 @@ public class SingleIssue extends Activity {
             final SimpleDateFormat dateFormat = new SimpleDateFormat(
                     Hubroid.GITHUB_ISSUES_TIME_FORMAT);
             final Date item_time = dateFormat.parse(pTime);
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - item_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;

--- a/src/net/idlesoft/android/apps/github/adapters/ActivityFeedAdapter.java
+++ b/src/net/idlesoft/android/apps/github/adapters/ActivityFeedAdapter.java
@@ -71,7 +71,7 @@ public class ActivityFeedAdapter extends JsonListAdapter {
             final SimpleDateFormat dateFormat = new SimpleDateFormat(
                     Hubroid.GITHUB_ISSUES_TIME_FORMAT);
             final Date item_time = dateFormat.parse(entry.getString("created_at"));
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - item_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;

--- a/src/net/idlesoft/android/apps/github/adapters/CommitListAdapter.java
+++ b/src/net/idlesoft/android/apps/github/adapters/CommitListAdapter.java
@@ -58,7 +58,7 @@ public class CommitListAdapter extends GravatarListAdapter {
             final SimpleDateFormat dateFormat = new SimpleDateFormat(Hubroid.GITHUB_TIME_FORMAT);
             final Date commit_time = dateFormat.parse(mJson.getJSONObject(index).getString(
                     "committed_date"));
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - commit_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;

--- a/src/net/idlesoft/android/apps/github/adapters/IssueCommentsAdapter.java
+++ b/src/net/idlesoft/android/apps/github/adapters/IssueCommentsAdapter.java
@@ -57,7 +57,7 @@ public class IssueCommentsAdapter extends GravatarListAdapter {
                     Hubroid.GITHUB_ISSUES_TIME_FORMAT);
             final Date item_time = dateFormat.parse(mJson.getJSONObject(index).getString(
                     "created_at"));
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - item_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;

--- a/src/net/idlesoft/android/apps/github/adapters/IssuesListAdapter.java
+++ b/src/net/idlesoft/android/apps/github/adapters/IssuesListAdapter.java
@@ -61,7 +61,7 @@ public class IssuesListAdapter extends JsonListAdapter {
                     Hubroid.GITHUB_ISSUES_TIME_FORMAT);
             final Date commit_time = dateFormat.parse(mJson.getJSONObject(index).getString(
                     "updated_at"));
-            final Date current_time = dateFormat.parse(dateFormat.format(new Date()));
+            final Date current_time = new Date();
             final long ms = current_time.getTime() - commit_time.getTime();
             final long sec = ms / 1000;
             final long min = sec / 60;


### PR DESCRIPTION
The previous version uses dateFormat.parse(dateFormat.format(new Date())) to get current time, which may result in incorrect time.
